### PR TITLE
Improve connection with blackmagic

### DIFF
--- a/src/api/rpc/blackmagic.js
+++ b/src/api/rpc/blackmagic.js
@@ -15,11 +15,7 @@ const CHANGE_ROOT_PASSWORD_RP = "change_root_password";
 const GET_SHELLS_LIST_RP = "get_shells_list";
 const ADD_USER_RP = "add_user";
 
-let rpcClient;
-
-export const connectToRpc = async () => {
-    rpcClient = await getRpcClient(blackmagicRpcURL);
-};
+const rpcClient = getRpcClient(blackmagicRpcURL);
 
 export const initialization = async (firmwareName, device, OS, buildType, callback) => (
     rpcClient.emit(INIT_RP, firmwareName, device, OS, buildType)

--- a/src/modules/Builder/components/Builder/Builder.jsx
+++ b/src/modules/Builder/components/Builder/Builder.jsx
@@ -11,8 +11,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import SidebarPage from "common/containers/SidebarPage";
 
-import * as RPC from "api/rpc/blackmagic";
-
 import { routes, baseRouteIndex, baseRoute } from "./config";
 
 export default class Builder extends Component {
@@ -36,10 +34,6 @@ export default class Builder extends Component {
         this.onNextBuildState = this.onNextBuildState.bind(this);
         this.currentStateRef = React.createRef();
         this.processStateData = this.processStateData.bind(this);
-    }
-
-    componentDidMount() {
-        RPC.connectToRpc();
     }
 
     onNextBuildState() {

--- a/src/root/Routes.jsx
+++ b/src/root/Routes.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import {
     BrowserRouter as Router,
+    Redirect,
     Route,
     Switch,
 } from "react-router-dom";
@@ -27,7 +28,10 @@ const Routes = (props) => {
 
                 <AuthRoute exact path="/dashboard" component={Dashboard} userIsAuth={userIsAuth} />
 
-                <AuthRoute path="/builder" component={Builder} userIsAuth={userIsAuth} />
+                <AuthRoute exact path="/builder" component={Builder} userIsAuth={userIsAuth} />
+                <Route path="/builder">
+                    <Redirect to="/builder" />
+                </Route>
 
                 <Route exact path="*" component={Error404} />
             </Switch>


### PR DESCRIPTION
It fixes the bug "TypeError: Cannot read property 'emit' of undefined", which occurs when the page is reloaded at any stage of the Builder, except the first one.