### PR TITLE
Import Link from react-router-dom instead of react-router-dom/Link

### DIFF
--- a/src/common/containers/Sidebar/Sidebar.jsx
+++ b/src/common/containers/Sidebar/Sidebar.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Nav } from "react-bootstrap";
-import Link from "react-router-dom/Link";
+import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 
 const Sidebar = ({ children }) => (


### PR DESCRIPTION
Warning appeared in the console:
```
Please use `require("react-router-dom").Link` instead of `require("react-router-dom/Link")`. Support for the latter will be removed in the next major release.
```